### PR TITLE
Tidier MultiQC Output

### DIFF
--- a/inst/scripts/multiqc/functions.R
+++ b/inst/scripts/multiqc/functions.R
@@ -1,0 +1,52 @@
+library(purrr, include.only = c("map", "map_chr", "reduce", "list_merge", "imap", "set_names"))
+
+remove_control_samples <- function(l) {
+  controls <- c("Alice", "Bob", "Chen", "Elon", "Dakota")
+  controls2 <- paste0(controls, rep(c("_T", "_B"), each = length(controls)))
+  # also remove 'idxstats' samples
+  controls_regex <- paste(c(controls2, "idxstats"), collapse = "|")
+  l <- l[!grepl(controls_regex, names(l))]
+  l
+}
+
+# Following are modified/simplified from TidyMultiqc
+parse_gen <- function(p) {
+  el <- "report_general_stats_data"
+  stopifnot(inherits(p, "list"), el %in% names(p))
+  p[[el]] |> reduce(~ list_merge(.x, !!!.y))
+}
+
+parse_raw <- function(p) {
+  el <- "report_saved_raw_data"
+  stopifnot(inherits(p, "list"), el %in% names(p))
+  # For each tool
+  p[[el]] |>
+    imap(function(samples, tool) {
+      # Remove the superflous "multiqc_" from the start of the tool name
+      tool <- sub("multiqc_", "", tool)
+
+      # For each sample
+      samples |> kv_map(function(metrics, sample) {
+        # For each metric in the above tool
+        list(
+          key = sample,
+          value = metrics |> kv_map(function(mvalue, mname) {
+            # Sanitise metric names
+            combined_metric <- list(
+              key = paste0(tool, ".", mname),
+              value = mvalue
+            )
+          })
+        )
+      })
+    }) |>
+    reduce(utils::modifyList)
+}
+
+kv_map <- function(l, func) {
+  mapped <- imap(l, func) |>
+    set_names(nm = NULL)
+  keys <- mapped |> map_chr("key")
+  vals <- mapped |> map("value")
+  vals |> set_names(keys)
+}

--- a/inst/scripts/multiqc/functions.R
+++ b/inst/scripts/multiqc/functions.R
@@ -17,7 +17,7 @@ mj2df <- function(json) {
   # - each variable has its own column
   # - each observation (sample) has its own row
   # - each value has its own cell
-  left_join(gen, raw, by = nm)
+  left_join(gen, raw, by = nm, suffix = c(".gen", ".raw"))
 }
 
 remove_control_samples <- function(l) {

--- a/inst/scripts/multiqc/tidy_multiqc.R
+++ b/inst/scripts/multiqc/tidy_multiqc.R
@@ -1,0 +1,25 @@
+library(arrow, include.only = "write_parquet")
+library(dplyr, include.only = c("bind_rows", "left_join"))
+library(readr, include.only = "write_tsv")
+library(RJSONIO, include.only = "fromJSON")
+source("functions.R")
+
+j <- "multiqc_data.json"
+p <- fromJSON(j)
+nm <- "umccr_subj_id"
+gen <- parse_gen(p) |>
+  remove_control_samples() |>
+  bind_rows(.id = nm)
+raw <- parse_raw(p) |>
+  remove_control_samples() |>
+  bind_rows(.id = nm)
+
+d <- dplyr::left_join(gen, raw, by = nm)
+# data is in tidy format:
+# - each variable has its own column
+# - each observation (sample) has its own row
+# - each value has its own cell
+
+# write to TSV and parquet format
+write_parquet(d, "test.parquet")
+write_tsv(d, "test.tsv")

--- a/inst/scripts/multiqc/tidy_multiqc.R
+++ b/inst/scripts/multiqc/tidy_multiqc.R
@@ -23,6 +23,11 @@ p <- add_argument(p,
 )
 args <- parse_args(p)
 
+
+stopifnot(
+  file.exists(args$json), is.character(args$name), nchar(args$name) > 0,
+  is.character(args$outdir), nchar(args$outdir) > 0
+)
 name <- args$name
 outdir <- normalizePath(mkdir(args$outdir))
 json <- args$json
@@ -30,7 +35,7 @@ json <- args$json
 # main function
 d <- mj2df(json)
 
-## write to TSV and parquet format
+## write to TSV and Parquet format
 tsv_out <- file.path(outdir, paste(name, "tsv", sep = "."))
 parquet_out <- file.path(outdir, paste(name, "parquet", sep = "."))
 write_tsv(d, tsv_out)


### PR DESCRIPTION
Added a script for exporting the `report_saved_raw_data` and `report_general_stats_data` elements from a UMCCR ('umccrised') MultiQC `multiqc_data.json` file into a 'tidier' TSV file (and a parquet file). 
TSV has ~640 columns (and two rows for T and N samples).
Main functions are based on `{TidyMultiqc}`, albeit a bit more simplified.

@brainstorm take a look if you can at https://arrow.apache.org/docs/r/reference/write_parquet.html and let me know if there are particular compression options you think are suitable.

```text
./tidy_multiqc.R \
  --json SBJ01050--488701/multiqc_data.json \
  --outdir test \
  --name SBJ01050

du -h test/*
292K	test/SBJ01050.parquet
 28K	test/SBJ01050.tsv
```

Dependencies for these scripts are:

```
# for functions
dplyr
purrr
RJSONIO
# for cli and data writing
argparser
arrow
readr
```

-- edit: just tested it on 52 samples (serially) and it worked without error and finished in 81 seconds on my 2017 Mac machine.