### PR TITLE
Add SNV counts to summary table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,5 +52,5 @@ ByteCompile: true
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr

--- a/R/rmd.R
+++ b/R/rmd.R
@@ -57,8 +57,8 @@ linx_rmd <- function(sample, table_dir, plot_dir, out_file = NULL, quiet = FALSE
 #'
 #' Generates a UMCCR Cancer Report. It does so with the following steps:
 #' 1. move the img_dir into 'tmp/img_dir'
-#' 2. copy the rmd into tmp/cancer_report.Rmd
-#' 3. render the rmd inside tmp/
+#' 2. copy the rmd into 'tmp/cancer_report.Rmd'
+#' 3. render the rmd inside 'tmp/'
 #' 4. return the path to the output HTML
 #'
 #' @param af_global Path to `af_tumor.txt` file.
@@ -67,29 +67,32 @@ linx_rmd <- function(sample, table_dir, plot_dir, out_file = NULL, quiet = FALSE
 #' @param conda_list Path to `conda_pkg_list.txt` file.
 #' @param img_dir Path to directory containing PURPLE plots.
 #' @param key_genes Path to UMCCR cancer gene file.
-#' @param somatic_snv_vcf Path to `somatic-PASS.vcf.gz` SNV VCF.
-#' @param somatic_sv_tsv Path to `manta.tsv` TSV file.
-#' @param somatic_sv_vcf Path to `manta.vcf.gz` VCF file.
-#' @param purple_som_gene_cnv Path to `purple.cnv.gene.tsv`.
-#' @param purple_som_cnv Path to `purple.cnv.somatic.tsv`.
+#' @param oncoviral_breakpoints_tsv Path to `oncoviruses/oncoviral_breakpoints.tsv`.
+#' @param oncoviral_present_viruses Path to `oncoviruses/present_viruses.txt`.
 #' @param purple_germ_cnv Path to `purple.cnv.germline.tsv`.
 #' @param purple_purity Path to `purple.purity.tsv`.
 #' @param purple_qc Path to `purple.qc`.
+#' @param purple_som_cnv Path to `purple.cnv.somatic.tsv`.
+#' @param purple_som_gene_cnv Path to `purple.cnv.gene.tsv`.
 #' @param purple_som_snv_vcf Path to `purple.somatic.vcf.gz`.
-#' @param oncoviral_present_viruses Path to `oncoviruses/present_viruses.txt`.
-#' @param oncoviral_breakpoints_tsv Path to `oncoviruses/oncoviral_breakpoints.tsv`.
+#' @param result_outdir Path to directory to write tidy JSON/TSV results.
+#' @param somatic_snv_summary Path to `somatic_snv_summary.json` JSON.
+#' @param somatic_snv_vcf Path to `somatic-PASS.vcf.gz` SNV VCF.
+#' @param somatic_sv_tsv Path to `manta.tsv` TSV file.
+#' @param somatic_sv_vcf Path to `manta.vcf.gz` VCF file.
+#' @param tumor_name Name of tumor sample.
 #' @param out_file Path to output HTML file (needs '.html' suffix) (def: `{tumor_name}_cancer_report.html`).
 #' @param quiet Suppress log printing during rendering.
-#' @param result_outdir Path to directory to write tidy JSON/TSV results.
-#' @param tumor_name Name of tumor sample.
 #'
 #' @return Path to rendered HTML report.
 #' @export
 cancer_rmd <- function(af_global, af_keygenes, batch_name, conda_list, img_dir, key_genes,
-                       somatic_snv_vcf, somatic_sv_tsv, somatic_sv_vcf, purple_som_gene_cnv,
-                       purple_som_cnv, purple_germ_cnv, purple_purity, purple_qc,
-                       purple_som_snv_vcf, oncoviral_present_viruses, oncoviral_breakpoints_tsv,
-                       result_outdir, tumor_name, out_file = NULL, quiet = FALSE) {
+                       oncoviral_breakpoints_tsv, oncoviral_present_viruses,
+                       purple_germ_cnv, purple_purity, purple_qc, purple_som_cnv,
+                       purple_som_gene_cnv, purple_som_snv_vcf, somatic_snv_summary,
+                       somatic_snv_vcf, somatic_sv_tsv, somatic_sv_vcf,
+                       result_outdir, tumor_name,
+                       out_file = NULL, quiet = FALSE) {
   assertthat::assert_that(
     dir.exists(img_dir),
     quiet %in% c(FALSE, TRUE)
@@ -119,6 +122,7 @@ cancer_rmd <- function(af_global, af_keygenes, batch_name, conda_list, img_dir, 
     conda_list = conda_list,
     img_dir = img_dir_b,
     key_genes = key_genes,
+    somatic_snv_summary = somatic_snv_summary,
     somatic_snv_vcf = somatic_snv_vcf,
     somatic_sv_tsv = somatic_sv_tsv,
     somatic_sv_vcf = somatic_sv_vcf,

--- a/inst/cli/canrep.R
+++ b/inst/cli/canrep.R
@@ -6,6 +6,7 @@ canrep_add_args <- function(subp) {
   canrep$add_argument("--conda_list", help = "Path to `conda_pkg_list.txt` file.", required = TRUE)
   canrep$add_argument("--img_dir", help = "Path to directory containing PURPLE plots.", required = TRUE)
   canrep$add_argument("--key_genes", help = "Path to UMCCR cancer gene file.", required = TRUE)
+  canrep$add_argument("--somatic_snv_summary", help = "Path to `somatic_snv_summary.json`.", required = TRUE)
   canrep$add_argument("--somatic_snv_vcf", help = "Path to `somatic-PASS.vcf.gz` SNV VCF.", required = TRUE)
   canrep$add_argument("--somatic_sv_tsv", help = "Path to `manta.tsv` TSV file.", required = TRUE)
   canrep$add_argument("--somatic_sv_vcf", help = "Path to `manta.vcf.gz` VCF file.", required = TRUE)
@@ -24,7 +25,6 @@ canrep_add_args <- function(subp) {
 }
 
 canrep_parse_args <- function(args) {
-  # print(c("You've called canrep Here are the arguments: ", args))
   cli::cli_h1("Start rendering UMCCR Cancer Report!")
   res <- gpgr::cancer_rmd(
     af_global = args$af_global,
@@ -33,6 +33,7 @@ canrep_parse_args <- function(args) {
     conda_list = args$conda_list,
     img_dir = args$img_dir,
     key_genes = args$key_genes,
+    somatic_snv_summary = args$somatic_snv_summary,
     somatic_snv_vcf = args$somatic_snv_vcf,
     somatic_sv_tsv = args$somatic_sv_tsv,
     somatic_sv_vcf = args$somatic_sv_vcf,

--- a/inst/rmd/umccrise/cancer_report.Rmd
+++ b/inst/rmd/umccrise/cancer_report.Rmd
@@ -10,26 +10,27 @@ output:
   rmdformats::material:
     highlight: kate
 params:
-  af_global: 'x'
-  af_keygenes: 'x'
-  batch_name: 'x'
-  conda_list: 'x'
-  img_dir: 'x'
-  key_genes: 'x'
-  oncoviral_present_viruses: 'x'
-  oncoviral_breakpoints_tsv: 'x'
-  purple_germ_cnv: 'x'
-  purple_purity: 'x'
-  purple_qc: 'x'
-  purple_som_cnv: 'x'
-  purple_som_gene_cnv: 'x'
-  purple_som_snv_vcf: 'x'
-  result_outdir: 'x'
-  somatic_snv_vcf: 'x'
-  somatic_sv_tsv: 'x'
-  somatic_sv_vcf: 'x'
+  af_global: NULL
+  af_keygenes: NULL
+  batch_name: NULL
+  conda_list: NULL
+  img_dir: NULL
+  key_genes: NULL
+  oncoviral_breakpoints_tsv: NULL
+  oncoviral_present_viruses: NULL
+  purple_germ_cnv: NULL
+  purple_purity: NULL
+  purple_qc: NULL
+  purple_som_cnv: NULL
+  purple_som_gene_cnv: NULL
+  purple_som_snv_vcf: NULL
+  result_outdir: NULL
+  somatic_snv_summary: NULL
+  somatic_snv_vcf: NULL
+  somatic_sv_tsv: NULL
+  somatic_sv_vcf: NULL
   title: "UMCCR Cancer Report"
-  tumor_name: 'x'
+  tumor_name: NULL
 description: "Analysis of tumor/normal samples at UMCCR"
 title: "`r paste(params$batch_name, params$title)`"
 ---
@@ -239,6 +240,25 @@ blank_lines(2)
 <details>
 <summary>Description</summary>
 
+__SNV Summary__
+
+Starting from the raw DRAGEN calls, count the number of variants remaining after
+each filtration stage.
+
+- `raw`: raw DRAGEN calls.
+- `raw_pass`: PASSed raw.
+- `noalt`: in chr1-22, X, Y, M.
+- `sage`: including rescued by SAGE.
+- `pregnomad`: should be the same as above.
+- `gnomad`: in the hypermutated case, total remaining after removing those
+  with `gnomAD_AF >= 0.01` (that are not in hotspots).
+- `anno`: after any additional filters for hypermutated case.
+- `filt`: after applying main filters (tumor allele frequency, PCGR tiers etc.). Should be the same as above.
+- `filt_pass`: after removing those that failed to pass the thresholds set above.
+- `giab`: after removing those that are __not__ in GIAB confident regions.
+
+__PURPLE Summary__
+
 PURPLE outputs a QC status along with a summary
 for the inferred purity and ploidy of the somatic sample.
 The 'QC Status' field reflects how we have determined the purity of the sample.
@@ -276,6 +296,14 @@ summarise_sigs <- function(mut_sig_contr) {
     dplyr::pull(string) %>%
     paste(collapse = ", ")
 }
+
+snv_summary <- params$somatic_snv_summary %>%
+  jsonlite::read_json() %>%
+  base::unlist() %>%
+  tibble::enframe() %>%
+  dplyr::mutate(x = glue("{name}: {value}")) %>%
+  dplyr::pull(x) %>%
+  base::paste(collapse = ", ")
 
 hrd_summary <- list(
   chord = chord_res[["prediction"]][, "p_hrd", drop = TRUE],
@@ -327,6 +355,7 @@ qc_summary_all <- dplyr::tribble(
     "Max: {cnv_summary[['germ']]$Max}; ",
     "N: {cnv_summary[['germ']]$N} "
   ), "",
+  17, "SNVs (Somatic)", snv_summary, "Summary of SNV filters, from raw to final.",
   18, "SVs (unmelted)", paste(rev(sv_summary$unmelted), collapse = ", "),
   "Summary of SVs as presented in raw VCF.",
   19, "SVs (melted)", paste(rev(sv_summary$melted), collapse = ", "),
@@ -371,6 +400,13 @@ qc_summary_all %>%
     )
   ) %>%
   gt::cols_align("left") %>%
+  # align rowname_col
+  gt::tab_style(
+    style = list(
+      cell_text(align = "left")
+    ),
+    locations = cells_stub(rows = TRUE)
+  ) %>%
   gt::opt_row_striping() %>%
   gt::tab_options(table.align = "left")
 
@@ -396,8 +432,6 @@ AFs range from 0 to 1, or 0%-100% (we filter out all novel variants with AF < 10
 <details>
 <summary>Details</summary>
 
-Variants are typically called in bcbio by 3 different callers, with calls supported by at least 2 of them used ("ensemble" approach).
-In some cases only a single caller is used due to technical reasons (e.g. highly mutated FFPE sample).
 
 The following post-processing steps occur:
 

--- a/inst/rmd/umccrise/render.R
+++ b/inst/rmd/umccrise/render.R
@@ -3,6 +3,7 @@
 require(here)
 require(gpgr)
 require(glue)
+require(purrr)
 
 batch_name <- "SBJ02269__PRJ221202"
 tumor_name <- "PRJ221202"
@@ -11,26 +12,29 @@ tumor_name <- "PRJ221202"
 umccrised_dir <- here::here("nogit/umccrised_data/SBJ02269")
 key_genes <- here::here("nogit/umccrised_data/umccr_cancer_genes.latest.tsv")
 
-
-gpgr::cancer_rmd(
+params <- list(
   af_global = glue::glue("{umccrised_dir}/work/{batch_name}/cancer_report/afs/af_tumor.txt"),
   af_keygenes = glue::glue("{umccrised_dir}/work/{batch_name}/cancer_report/afs/af_tumor_keygenes.txt"),
   batch_name = batch_name,
   conda_list = glue::glue("{umccrised_dir}/work/{batch_name}/conda_pkg_list.txt"),
   img_dir = glue::glue("{umccrised_dir}/img"),
   key_genes = key_genes,
-  somatic_snv_vcf = glue::glue("{umccrised_dir}/{batch_name}/small_variants/{batch_name}-somatic-PASS.vcf.gz"),
-  somatic_sv_tsv = glue::glue("{umccrised_dir}/{batch_name}/structural/{batch_name}-manta.tsv"),
-  somatic_sv_vcf = glue::glue("{umccrised_dir}/{batch_name}/structural/{batch_name}-manta.vcf.gz"),
-  purple_som_gene_cnv = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.cnv.gene.tsv"),
-  purple_som_cnv = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.cnv.somatic.tsv"),
+  oncoviral_breakpoints_tsv = glue::glue("{umccrised_dir}/work/{batch_name}/oncoviruses/oncoviral_breakpoints.tsv"),
+  oncoviral_present_viruses = glue::glue("{umccrised_dir}/work/{batch_name}/oncoviruses/present_viruses.txt"),
+  out_file = here::here("nogit/umccrised_data/SBJ02269/foo_cancer_report.html"),
   purple_germ_cnv = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.cnv.germline.tsv"),
   purple_purity = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.purity.tsv"),
   purple_qc = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.qc"),
+  purple_som_cnv = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.cnv.somatic.tsv"),
+  purple_som_gene_cnv = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.cnv.gene.tsv"),
   purple_som_snv_vcf = glue::glue("{umccrised_dir}/work/{batch_name}/purple/{batch_name}.purple.somatic.vcf.gz"),
-  oncoviral_present_viruses = glue::glue("{umccrised_dir}/work/{batch_name}/oncoviruses/present_viruses.txt"),
-  oncoviral_breakpoints_tsv = glue::glue("{umccrised_dir}/work/{batch_name}/oncoviruses/oncoviral_breakpoints.tsv"),
-  out_file = here::here("nogit/umccrised_data/SBJ02269/foo_cancer_report.html"),
   result_outdir = glue::glue("{umccrised_dir}/{batch_name}/cancer_report_tables2"),
+  somatic_snv_summary = glue::glue("{umccrised_dir}/work/{batch_name}/cancer_report/somatic_snv_summary.json"),
+  somatic_snv_vcf = glue::glue("{umccrised_dir}/{batch_name}/small_variants/{batch_name}-somatic-PASS.vcf.gz"),
+  somatic_sv_tsv = glue::glue("{umccrised_dir}/{batch_name}/structural/{batch_name}-manta.tsv"),
+  somatic_sv_vcf = glue::glue("{umccrised_dir}/{batch_name}/structural/{batch_name}-manta.vcf.gz"),
   tumor_name = tumor_name
 )
+
+# awesomeness
+purrr::lift_dl(gpgr::cancer_rmd)(params)

--- a/inst/rmd/umccrise/render.sh
+++ b/inst/rmd/umccrise/render.sh
@@ -15,20 +15,21 @@ $gpgr_cli canrep \
   --af_global "${umccrised_dir}/work/${batch_name}/cancer_report/afs/af_tumor.txt" \
   --af_keygenes "${umccrised_dir}/work/${batch_name}/cancer_report/afs/af_tumor_keygenes.txt" \
   --batch_name "${batch_name}" \
-  --conda_list  "${umccrised_dir}/work/${batch_name}/conda_pkg_list.txt" \
+  --conda_list "${umccrised_dir}/work/${batch_name}/conda_pkg_list.txt" \
   --img_dir "${umccrised_dir}/img" \
-  --key_genes  "${key_genes}" \
-  --somatic_snv_vcf  "${umccrised_dir}/${batch_name}/small_variants/${batch_name}-somatic-PASS.vcf.gz" \
-  --somatic_sv_tsv  "${umccrised_dir}/${batch_name}/structural/${batch_name}-manta.tsv" \
-  --somatic_sv_vcf  "${umccrised_dir}/${batch_name}/structural/${batch_name}-manta.vcf.gz" \
-  --purple_som_gene_cnv  "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.cnv.gene.tsv" \
-  --purple_som_cnv  "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.cnv.somatic.tsv" \
-  --purple_germ_cnv  "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.cnv.germline.tsv" \
-  --purple_purity  "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.purity.tsv" \
-  --purple_qc  "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.qc" \
-  --purple_som_snv_vcf  "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.somatic.vcf.gz" \
-  --oncoviral_present_viruses  "${umccrised_dir}/work/${batch_name}/oncoviruses/present_viruses.txt" \
-  --oncoviral_breakpoints_tsv  "${umccrised_dir}/work/${batch_name}/oncoviruses/oncoviral_breakpoints.tsv" \
-  --out_file  "${gpgr_dir}/nogit/umccrised_data/cancer_report_2269.html" \
-  --result_outdir  "${umccrised_dir}/${batch_name}/cancer_report_tables2" \
-  --tumor_name  tumor_name
+  --key_genes "${key_genes}" \
+  --somatic_snv_summary "${umccrised_dir}/work/${batch_name}/cancer_report/somatic_snv_summary.json" \
+  --somatic_snv_vcf "${umccrised_dir}/${batch_name}/small_variants/${batch_name}-somatic-PASS.vcf.gz" \
+  --somatic_sv_tsv "${umccrised_dir}/${batch_name}/structural/${batch_name}-manta.tsv" \
+  --somatic_sv_vcf "${umccrised_dir}/${batch_name}/structural/${batch_name}-manta.vcf.gz" \
+  --purple_som_gene_cnv "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.cnv.gene.tsv" \
+  --purple_som_cnv "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.cnv.somatic.tsv" \
+  --purple_germ_cnv "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.cnv.germline.tsv" \
+  --purple_purity "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.purity.tsv" \
+  --purple_qc "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.qc" \
+  --purple_som_snv_vcf "${umccrised_dir}/work/${batch_name}/purple/${batch_name}.purple.somatic.vcf.gz" \
+  --oncoviral_present_viruses "${umccrised_dir}/work/${batch_name}/oncoviruses/present_viruses.txt" \
+  --oncoviral_breakpoints_tsv "${umccrised_dir}/work/${batch_name}/oncoviruses/oncoviral_breakpoints.tsv" \
+  --out_file "${gpgr_dir}/nogit/umccrised_data/cancer_report_2269.html" \
+  --result_outdir "${umccrised_dir}/${batch_name}/cancer_report_tables2" \
+  --tumor_name ${tumor_name}

--- a/man/cancer_rmd.Rd
+++ b/man/cancer_rmd.Rd
@@ -11,17 +11,18 @@ cancer_rmd(
   conda_list,
   img_dir,
   key_genes,
-  somatic_snv_vcf,
-  somatic_sv_tsv,
-  somatic_sv_vcf,
-  purple_som_gene_cnv,
-  purple_som_cnv,
+  oncoviral_breakpoints_tsv,
+  oncoviral_present_viruses,
   purple_germ_cnv,
   purple_purity,
   purple_qc,
+  purple_som_cnv,
+  purple_som_gene_cnv,
   purple_som_snv_vcf,
-  oncoviral_present_viruses,
-  oncoviral_breakpoints_tsv,
+  somatic_snv_summary,
+  somatic_snv_vcf,
+  somatic_sv_tsv,
+  somatic_sv_vcf,
   result_outdir,
   tumor_name,
   out_file = NULL,
@@ -41,15 +42,9 @@ cancer_rmd(
 
 \item{key_genes}{Path to UMCCR cancer gene file.}
 
-\item{somatic_snv_vcf}{Path to \code{somatic-PASS.vcf.gz} SNV VCF.}
+\item{oncoviral_breakpoints_tsv}{Path to \code{oncoviruses/oncoviral_breakpoints.tsv}.}
 
-\item{somatic_sv_tsv}{Path to \code{manta.tsv} TSV file.}
-
-\item{somatic_sv_vcf}{Path to \code{manta.vcf.gz} VCF file.}
-
-\item{purple_som_gene_cnv}{Path to \code{purple.cnv.gene.tsv}.}
-
-\item{purple_som_cnv}{Path to \code{purple.cnv.somatic.tsv}.}
+\item{oncoviral_present_viruses}{Path to \code{oncoviruses/present_viruses.txt}.}
 
 \item{purple_germ_cnv}{Path to \code{purple.cnv.germline.tsv}.}
 
@@ -57,11 +52,19 @@ cancer_rmd(
 
 \item{purple_qc}{Path to \code{purple.qc}.}
 
+\item{purple_som_cnv}{Path to \code{purple.cnv.somatic.tsv}.}
+
+\item{purple_som_gene_cnv}{Path to \code{purple.cnv.gene.tsv}.}
+
 \item{purple_som_snv_vcf}{Path to \code{purple.somatic.vcf.gz}.}
 
-\item{oncoviral_present_viruses}{Path to \code{oncoviruses/present_viruses.txt}.}
+\item{somatic_snv_summary}{Path to \code{somatic_snv_summary.json} JSON.}
 
-\item{oncoviral_breakpoints_tsv}{Path to \code{oncoviruses/oncoviral_breakpoints.tsv}.}
+\item{somatic_snv_vcf}{Path to \code{somatic-PASS.vcf.gz} SNV VCF.}
+
+\item{somatic_sv_tsv}{Path to \code{manta.tsv} TSV file.}
+
+\item{somatic_sv_vcf}{Path to \code{manta.vcf.gz} VCF file.}
 
 \item{result_outdir}{Path to directory to write tidy JSON/TSV results.}
 
@@ -78,8 +81,8 @@ Path to rendered HTML report.
 Generates a UMCCR Cancer Report. It does so with the following steps:
 \enumerate{
 \item move the img_dir into 'tmp/img_dir'
-\item copy the rmd into tmp/cancer_report.Rmd
-\item render the rmd inside tmp/
+\item copy the rmd into 'tmp/cancer_report.Rmd'
+\item render the rmd inside 'tmp/'
 \item return the path to the output HTML
 }
 }


### PR DESCRIPTION
This adds a summary of SNV VCF variant counts to the umccrise cancer report summary table, starting from the raw DRAGEN calls all the way to the final passed set. Might be useful for getting an idea about the impact of the filtration steps, and will also indicate if the sample was hypermutated. Lame example screenshot attached below.

<img width="900" alt="Screen Shot 2022-08-24 at 01 38 38" src="https://user-images.githubusercontent.com/29562861/186201585-3f41a236-488f-4cba-8f4b-9a57b97a0b6c.png">
<img width="1120" alt="Screen Shot 2022-08-24 at 01 38 55" src="https://user-images.githubusercontent.com/29562861/186201624-a855f20d-4f85-4d31-965d-26fee140b066.png">

