### PR TITLE
Update test data

### DIFF
--- a/R/oncokb.R
+++ b/R/oncokb.R
@@ -5,7 +5,7 @@
 #' @return Vector of genes.
 #' @export
 read_oncokb <- function(x) {
-  readr::read_tsv(x) |>
+  readr::read_tsv(x, col_types = readr::cols(.default = "c")) |>
     dplyr::filter(
       .data$`OncoKB Annotated` == "Yes"
     ) |>

--- a/R/umccrise.R
+++ b/R/umccrise.R
@@ -30,7 +30,7 @@ bcftools_stats_plot <- function(x = NULL) {
   tot <- nrow(d)
   p <- d |>
     ggplot2::ggplot(ggplot2::aes(x = .data$qual)) +
-    ggplot2::geom_histogram(ggplot2::aes(y = ggplot2::after_stat(stats::density)), binwidth = 4, fill = "lightblue") +
+    ggplot2::geom_histogram(ggplot2::aes(y = ggplot2::after_stat(.data$density)), binwidth = 4, fill = "lightblue") +
     ggplot2::geom_density(alpha = 0.6) +
     ggplot2::geom_vline(xintercept = med, colour = "blue", linetype = "dashed") +
     ggplot2::scale_x_continuous(n.breaks = 10) +
@@ -39,7 +39,7 @@ bcftools_stats_plot <- function(x = NULL) {
       label = paste0("Median: ", med),
     ) +
     ggplot2::theme_bw() +
-    ggplot2::ggtitle(glue::glue("SNV quality score distribution (total SNVs: {tot})"))
+    ggplot2::ggtitle(glue::glue("Small variant quality score distribution (total variants: {tot})"))
   p
 }
 

--- a/inst/extdata/purple/purple.cnv.gene.tsv.dvc
+++ b/inst/extdata/purple/purple.cnv.gene.tsv.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: b9ad0a338ab1cfbcf5f77f2923f5a923
-  size: 30990
+- md5: da76078daae06437450548aae81bc20e
+  size: 28325
   path: purple.cnv.gene.tsv
+  hash: md5

--- a/inst/extdata/purple/purple.purity.tsv.dvc
+++ b/inst/extdata/purple/purple.purity.tsv.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: 63c8fc94da99b388021904993ce16c4a
-  size: 451
+- md5: b7e6e168bb07e3dc3bcab9934cda9094
+  size: 482
   path: purple.purity.tsv
+  hash: md5

--- a/inst/extdata/purple/purple.qc.dvc
+++ b/inst/extdata/purple/purple.qc.dvc
@@ -1,4 +1,5 @@
 outs:
-- md5: afaa81edd722f89f32df3439dc24979e
-  size: 208
+- md5: c10f44c2a7dc2b29cd2971efc94e0b0d
+  size: 228
   path: purple.qc
+  hash: md5

--- a/inst/extdata/ref/.gitignore
+++ b/inst/extdata/ref/.gitignore
@@ -1,0 +1,1 @@
+/umccr_cancer_genes_v24.03.0.tsv

--- a/inst/extdata/ref/umccr_cancer_genes_v24.03.0.tsv.dvc
+++ b/inst/extdata/ref/umccr_cancer_genes_v24.03.0.tsv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 28424e4e24fa8da80a431c832b3dd011
+  size: 13441
+  hash: md5
+  path: umccr_cancer_genes_v24.03.0.tsv

--- a/inst/extdata/sash/.gitignore
+++ b/inst/extdata/sash/.gitignore
@@ -1,0 +1,1 @@
+/sv.prioritised.tsv

--- a/inst/extdata/sash/sv.prioritised.tsv.dvc
+++ b/inst/extdata/sash/sv.prioritised.tsv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 4f5c6f721a2d4edb7dc3d30d0ce9054a
+  size: 476080
+  hash: md5
+  path: sv.prioritised.tsv

--- a/inst/extdata/virusbreakend/.gitignore
+++ b/inst/extdata/virusbreakend/.gitignore
@@ -1,0 +1,2 @@
+/virusbreakend.vcf
+/virusbreakend.vcf.summary.tsv

--- a/inst/extdata/virusbreakend/virusbreakend.vcf.dvc
+++ b/inst/extdata/virusbreakend/virusbreakend.vcf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: d965ed90d5b1757549ed4b5682b586b3
+  size: 189585
+  hash: md5
+  path: virusbreakend.vcf

--- a/inst/extdata/virusbreakend/virusbreakend.vcf.summary.tsv.dvc
+++ b/inst/extdata/virusbreakend/virusbreakend.vcf.summary.tsv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 01057e3ee3a1cd0f0a162d221cb0afb3
+  size: 573
+  hash: md5
+  path: virusbreakend.vcf.summary.tsv

--- a/inst/rmd/umccrise/cancer_report.Rmd
+++ b/inst/rmd/umccrise/cancer_report.Rmd
@@ -48,30 +48,30 @@ knitr::opts_chunk$set(
 
 ```{r load_pkgs}
 # Bioconductor
-library(BSgenome)
-library(MutationalPatterns)
+library(BSgenome, include.only = "BSgenome")
+library(MutationalPatterns, include.only = "read_vcfs_as_granges")
 ref_genome <- "BSgenome.Hsapiens.UCSC.hg38"
-library(ref_genome, character.only = TRUE)
+library(ref_genome, character.only = TRUE, include.only = ref_genome)
 tx_ref_genome <- "TxDb.Hsapiens.UCSC.hg38.knownGene"
-library(tx_ref_genome, character.only = TRUE)
+library(tx_ref_genome, character.only = TRUE, include.only = tx_ref_genome)
 # CRAN
-library(devtools)
-library(details)
-library(DT)
+library(details, include.only = "details")
+library(DT, include.only = "datatable")
 library(dplyr)
-library(glue)
-library(gt)
-library(ggplot2)
-library(htmltools)
-library(jsonlite)
+library(GenomeInfoDb, include.only = "seqlevelsStyle")
+library(GenomicFeatures, include.only = "genes")
+library(GenomicRanges, include.only = "GRanges")
+library(glue, include.only = "glue")
+library(gt, include.only = "gt")
+library(ggplot2, include.only = "ggtitle")
+library(IRanges, include.only = "IRanges")
 library(knitr)
-library(kableExtra)
+library(kableExtra, include.only = "kable_styling")
 library(patchwork)
-library(purrr)
-library(readr)
-library(rmarkdown)
-library(stringr)
-library(tidyr)
+library(purrr, include.only = "map")
+library(readr, include.only = "read_tsv")
+library(rmarkdown, include.only = "render")
+library(tidyr, include.only = "pivot_longer")
 # umccr
 library(gpgr)
 library(sigrap)
@@ -388,50 +388,50 @@ qc_summary_all %>%
   gt::gt(rowname_col = "variable") %>%
   gt::tab_style(
     style = list(
-      cell_fill(color = red),
-      cell_text(weight = "bold")
+      gt::cell_fill(color = red),
+      gt::cell_text(weight = "bold")
     ),
-    locations = cells_body(
+    locations = gt::cells_body(
       columns = value,
       rows = grepl("FAIL", value) & variable == "QC_Status"
     )
   ) %>%
   gt::tab_style(
     style = list(
-      cell_fill(color = orange),
-      cell_text(weight = "bold")
+      gt::cell_fill(color = orange),
+      gt::cell_text(weight = "bold")
     ),
-    locations = cells_body(
+    locations = gt::cells_body(
       columns = value,
       rows = grepl("WARN_", value) & variable == "QC_Status"
     )
   ) %>%
   gt::tab_style(
     style = list(
-      cell_fill(color = orange),
-      cell_text(weight = "bold")
+      gt::cell_fill(color = orange),
+      gt::cell_text(weight = "bold")
     ),
-    locations = cells_body(
+    locations = gt::cells_body(
       columns = value,
       rows = grepl("TRUE", value) & variable == "Hypermutated"
     )
   ) %>%
   gt::tab_style(
     style = list(
-      cell_text(weight = "bold")
+      gt::cell_text(weight = "bold")
     ),
     locations = list(
-      cells_stub(rows = TRUE),
-      cells_body(columns = value)
+      gt::cells_stub(rows = TRUE),
+      gt::cells_body(columns = value)
     )
   ) %>%
   gt::cols_align("left") %>%
   # align rowname_col
   gt::tab_style(
     style = list(
-      cell_text(align = "left")
+      gt::cell_text(align = "left")
     ),
-    locations = cells_stub(rows = TRUE)
+    locations = gt::cells_stub(rows = TRUE)
   ) %>%
   gt::opt_row_striping() %>%
   gt::tab_options(table.align = "left")
@@ -560,7 +560,6 @@ mp_plot_bias2 <- MutationalPatterns::plot_strand_bias(strand_bias)
 
 
 ## ---- Replicative ---- ##
-
 repli_file <- system.file("extdata/ReplicationDirectionRegions.bed",
   package = "MutationalPatterns"
 )
@@ -1012,9 +1011,9 @@ d %>%
   gt::sub_missing(columns = dplyr::everything()) %>%
   gt::tab_style(
     style = list(
-      cell_text(weight = "bold")
+      gt::cell_text(weight = "bold")
     ),
-    locations = cells_stub(rows = TRUE)
+    locations = gt::cells_stub(rows = TRUE)
   ) %>%
   gt::cols_align("right") %>%
   gt::tab_options(table.align = "left")
@@ -1135,7 +1134,7 @@ purple_cnv_som_gene$descr %>%
   dplyr::mutate(
     Column = kableExtra::cell_spec(Column, bold = TRUE)
   ) %>%
-  knitr::kable(escape = FALSE) %>%
+  kableExtra::kbl(escape = FALSE) %>%
   kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::scroll_box(height = "200px")
 ```
@@ -1178,7 +1177,7 @@ purple_cnv_som$descr %>%
   dplyr::mutate(
     Column = kableExtra::cell_spec(Column, bold = TRUE)
   ) %>%
-  knitr::kable(escape = FALSE) %>%
+  kableExtra::kbl(escape = FALSE) %>%
   kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::scroll_box(height = "200px")
 ```
@@ -1371,7 +1370,7 @@ if (is.null(params$conda_list)) {
     )
   ) %>%
     dplyr::left_join(conda_pkgs, by = "name") %>%
-    knitr::kable(format = "html") %>%
+    kableExtra::kbl() %>%
     kableExtra::kable_paper(c("hover", "striped"), full_width = TRUE, position = "left") %>%
     kableExtra::column_spec(1, bold = TRUE) %>%
     kableExtra::scroll_box(height = "300px")
@@ -1383,9 +1382,8 @@ if (is.null(params$conda_list)) {
 ```{r report_inputs}
 report_inputs <- dplyr::tibble(key = names(params), value = params)
 gpgr::write_tsvjsongz(report_inputs, glue("{bnm}-report_inputs"), result_outdir)
-
 report_inputs %>%
-  knitr::kable(format = "html") %>%
+  kableExtra::kbl() %>%
   kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::column_spec(1, bold = TRUE) %>%
   kableExtra::scroll_box(height = "200px")

--- a/inst/rmd/umccrise/render.R
+++ b/inst/rmd/umccrise/render.R
@@ -7,8 +7,7 @@ require(purrr)
 
 batch_name <- "SBJ00480_PTC_HCC1395t100pc"
 tumor_name <- "PTC_HCC1395t100pc"
-umccrised_dir <- here("nogit/umccrised_data/seqc_inputs.20231115")
-
+umccrised_dir <- here::here("nogit/umccrised_data/seqc_inputs.20231115")
 params <- list(
   af_global = glue("{umccrised_dir}/sample_data/af_tumor.txt"),
   af_keygenes = glue("{umccrised_dir}/sample_data/af_tumor_keygenes.txt"),
@@ -17,7 +16,7 @@ params <- list(
   conda_list = NULL,
   dragen_hrd = glue("{umccrised_dir}/sample_data/{tumor_name}.hrdscore.csv"),
   img_dir = glue("{umccrised_dir}/output/img"),
-  key_genes = glue("{umccrised_dir}/reference_data/umccr_cancer_genes.latest.tsv"),
+  key_genes = normalizePath("./inst/extdata/ref/umccr_cancer_genes_v24.03.0.tsv"),
   oncokb_genes = glue("{umccrised_dir}/reference_data/oncokb_genes.20231113.tsv"),
   virusbreakend_tsv = glue("{umccrised_dir}/sample_data/virusbreakend/{batch_name}.virusbreakend.vcf.summary.tsv"),
   virusbreakend_vcf = glue("{umccrised_dir}/sample_data/virusbreakend/{batch_name}.virusbreakend.vcf"),
@@ -30,8 +29,8 @@ params <- list(
   result_outdir = glue("{umccrised_dir}/output/cancer_report_tables"),
   somatic_snv_vcf = glue("{umccrised_dir}/sample_data/{tumor_name}.pass.vcf.gz"),
   somatic_snv_summary = glue("{umccrised_dir}/sample_data/{tumor_name}.somatic.variant_counts_process.json"),
-  somatic_sv_tsv = glue("{umccrised_dir}/sample_data/{tumor_name}.sv.prioritised.tsv"),
-  somatic_sv_vcf = glue("{umccrised_dir}/sample_data/{tumor_name}.sv.prioritised.vcf.gz"),
+  somatic_sv_tsv = here::here("inst/extdata/sash/sv.prioritised.tsv"),
+  somatic_sv_vcf = here::here("inst/extdata/sash/sv.prioritised.vcf.gz"),
   tumor_name = tumor_name
 )
 


### PR DESCRIPTION
Some data updates (fixes #77 and fixes #75).

- Updating: purple `cnv.gene`, `purity`, `qc`
- Adding: 
  - virusbreakend `vcf` and `vcf.summary.tsv`
  - `umccr_cancer_genes_v24.03.0.tsv` (the data download script was actually edited in the previous PR at https://github.com/umccr/gpgr/blob/c1cda25/data-raw/umccr_cancer_genes.R)

- Edited the bcftools qual plot title to say `Small variant` instead of `SNV`, since it includes indels.