### PR TITLE
GitHub Actions Updates

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,11 +24,10 @@ jobs:
 
     steps:
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Micromamba setup
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: '1.4.9-0'
           environment-file: ${{ env.env_yaml_path }}/condabuild.yaml
       - name: 🐍 Conda pkg build and upload
         run: |
@@ -37,8 +36,9 @@ jobs:
           conda mambabuild --R 4.2 ${recipe_path} --token ${atoken}
       - name: 🔒 Conda lock
         run: |
-          conda-lock --file ${env_yaml_path}/gpgr.yaml --platform linux-64
-          mv conda-lock.yml ${env_lock_path}/conda-lock.yml
+          conda-lock lock --file ${env_yaml_path}/gpgr.yaml --platform linux-64
+          conda-lock render --kind explicit -p linux-64 conda-lock.yml --filename-template 'gpgr-{platform}.lock' && rm conda-lock.yml
+          mv gpgr-*.lock ${env_lock_path}/
       - name: 💾 Commit lockfile
         run: |
           # TODO: the version bumping guarantees there will be changes,
@@ -67,7 +67,7 @@ jobs:
           LATEST_COMMIT_HASH="$(git --no-pager log -1 --format='%H')"
           echo "latest_commit_hash=${LATEST_COMMIT_HASH}" >> $GITHUB_OUTPUT
       - name: 🔖 Create tag
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           LATEST_COMMIT_HASH: ${{ steps.pull_lock_commit.outputs.latest_commit_hash }}
         with:
@@ -83,26 +83,26 @@ jobs:
 
       # work with tag from above
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: v${{ env.VERSION }}
       - name: 🏰 QEMU setup
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: 🏯 Buildx setup
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
           config-inline: |
             [worker.oci]
               max-parallelism = 2
       - name: 🐙 GitHub CR login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: 🐳 Docker img build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           tags: ghcr.io/${{ github.repository }}:${{ env.VERSION }}
           context: . # yes, dot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="https://github.com/pdiakumis"
 
-ARG MINI_VERSION=4.12.0-0
+ARG MINI_VERSION=24.3.0-0
 ARG MINI_URL=https://github.com/conda-forge/miniforge/releases/download/${MINI_VERSION}/Mambaforge-${MINI_VERSION}-Linux-x86_64.sh
 ARG MAMBA_PREFIX="/opt/mambaforge"
 
@@ -22,8 +22,8 @@ ARG ENV_DIR=/home/gpgr_conda_env
 ARG ENV_NAME="gpgr_env"
 COPY ./conda/env/lock ${ENV_DIR}
 RUN conda config --set always_yes yes && \
-    mamba install -c conda-forge conda-lock==1.0.5
-RUN conda-lock install --name ${ENV_NAME} ${ENV_DIR}/conda-lock.yml && \
+    mamba install -c conda-forge conda-lock
+RUN conda-lock install --name ${ENV_NAME} ${ENV_DIR}/gpgr-linux-64.lock && \
     mamba clean --all --force-pkgs-dirs
 
 ENV PATH="${MAMBA_PREFIX}/envs/${ENV_NAME}/bin:${PATH}"


### PR DESCRIPTION
Updating action versions, refactoring conda-lock command, adjusting Dockerfile (hopefully this works).
Probably should move away from mambaforge in the future and stick with miniforge since it's getting phased out.