### PR TITLE
ci: add workflow_dispatch dev release for sash #52 E2E testing

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,0 +1,38 @@
+name: dev-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker image tag (e.g. 2.3.1-sash52)'
+        required: true
+
+jobs:
+  build-push:
+    name: Build and push dev Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+      - name: QEMU setup
+        uses: docker/setup-qemu-action@v3
+      - name: Buildx setup
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 2
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/gpgr:${{ inputs.tag }}
+          platforms: linux/amd64

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -11,6 +11,9 @@ jobs:
   build-push:
     name: Build and push dev Docker image
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -23,16 +26,16 @@ jobs:
           config-inline: |
             [worker.oci]
               max-parallelism = 2
-      - name: Docker Hub login
+      - name: GitHub CR login
         uses: docker/login-action@v3
         with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/gpgr:${{ inputs.tag }}
+          tags: ghcr.io/${{ github.repository }}:${{ inputs.tag }}
           platforms: linux/amd64

--- a/tests/testthat/test-canrep-cli.R
+++ b/tests/testthat/test-canrep-cli.R
@@ -1,0 +1,51 @@
+# Tests for canrep CLI argument parsing
+# Guards against regression where --dragen_hrd was accidentally marked required=TRUE
+# (introduced in 563f946, fixed in PR #94 and again in 2.3.1)
+
+canrep_parser <- function() {
+  cli_path <- system.file("cli/canrep.R", package = "gpgr")
+  source(cli_path, local = TRUE)
+  p <- argparse::ArgumentParser()
+  sp <- p$add_subparsers(dest = "command")
+  canrep_add_args(sp)
+  p
+}
+
+required_args <- function() {
+  c(
+    "canrep",
+    "--af_global", "x",
+    "--af_keygenes", "x",
+    "--batch_name", "x",
+    "--img_dir", "x",
+    "--key_genes", "x",
+    "--oncokb_genes", "x",
+    "--somatic_snv_vcf", "x",
+    "--somatic_snv_summary", "x",
+    "--somatic_sv_tsv", "x",
+    "--somatic_sv_vcf", "x",
+    "--purple_som_gene_cnv", "x",
+    "--purple_som_cnv_ann", "x",
+    "--purple_som_cnv", "x",
+    "--purple_purity", "x",
+    "--purple_qc", "x",
+    "--purple_som_snv_vcf", "x",
+    "--virusbreakend_tsv", "x",
+    "--virusbreakend_vcf", "x",
+    "--bcftools_stats", "x",
+    "--result_outdir", "x",
+    "--tumor_name", "x"
+  )
+}
+
+test_that("canrep parses without --dragen_hrd (optional)", {
+  p <- canrep_parser()
+  args <- p$parse_args(required_args())
+  expect_null(args$dragen_hrd)
+})
+
+test_that("canrep parses with --dragen_hrd when provided", {
+  p <- canrep_parser()
+  args <- p$parse_args(c(required_args(), "--dragen_hrd", "sample.hrdscore.csv"))
+  expect_equal(args$dragen_hrd, "sample.hrdscore.csv")
+})


### PR DESCRIPTION
## Summary
Adds a manually-triggered (`workflow_dispatch`) GitHub Actions workflow to build and push a dev Docker image, for E2E-testing sash #52 (PCGR skip on high variant count) fixes before they're formally released.

**Fixed before opening this PR** (caught by review): the original commit logged into `docker.io` using `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets — neither is configured on this repo (verified via `gh secret list`), so every run would have failed at the login step. It also pushed to a personal Docker Hub account, the same anti-pattern flagged as a blocking governance finding in the sash 0.7.0 release audit (`qclayssen/sigrap:0.2.0-dev-7`). Switched to `ghcr.io/umccr/gpgr` using the built-in `GITHUB_TOKEN`, matching this repo's existing `deploy.yaml` convention exactly — no new secrets required.

## Test plan
- [x] YAML structurally validated
- [x] Registry/auth pattern matches `deploy.yaml` (already in production use)
- [ ] Not yet run via `workflow_dispatch` — first real trigger will be the actual validation